### PR TITLE
Redesign of the datasetall pages

### DIFF
--- a/preflibApp/static/css/style.css
+++ b/preflibApp/static/css/style.css
@@ -397,8 +397,13 @@ li li {
 
 a {
 	font-style: italic;
-	color: var(--color-blue2);
+	/* color: var(--color-blue2); */
+	color: #607fb9;
 	text-decoration: none;
+}
+
+a:hover {
+	text-decoration: underline;
 }
 
 .content {
@@ -788,6 +793,40 @@ Index page
 All datasets page
 ========= */
 
+ul#dataset-list {
+	list-style-type: none;
+	padding: 0;
+	margin: 0;
+}
+
+ul#dataset-list li {
+	border-top: 1px solid #ddd;
+	padding-top: 0;
+	font-size: 100%;
+}
+
+ul#dataset-list .dataset-title {
+	margin-top: 0.5em;
+	margin-bottom: 0;
+	font-size: 135%;
+}
+
+ul#dataset-list .dataset-number {
+	font-size: 100%;
+	margin-top: 0;
+	color: #444;
+}
+
+ul#dataset-list .dataset-description {
+	border-left: 6px solid var(--color-blue3);
+	padding-left: 10px;
+}
+
+.data-patch-list {
+	line-height: 1.4;
+	margin-bottom: 0;
+}
+
 .data-patch-list .data-patch {
 	font-size: 80%;
 	background-color: var(--color-blue3);
@@ -803,7 +842,7 @@ All datasets page
 
 .button-row {
 	display: flex;
-	justify-content: center;
+	/* justify-content: center; */
 	margin-top: 10px;
 	gap: 10px;
 }
@@ -820,6 +859,44 @@ All datasets page
 
 .button-row a:hover {
 	background-color: var(--color-blue1);
+}
+
+nav#dataset-menu {
+	display: none;
+}
+
+@media screen and (min-width: 1100px) {
+	#section-datasets {
+		display: grid;
+    	grid-template-columns: 320px 1fr;
+	}
+
+	nav#dataset-menu {
+		display: block;
+	}
+
+	nav#dataset-menu ul {
+		position: sticky;
+		top: 1em;
+		list-style-type: none;
+		padding: 0;
+		margin: 0;
+		margin-left: -5px;
+		overflow-y: scroll;
+		max-height: 100vh;
+		font-size: 90%;
+	}
+
+	nav#dataset-menu ul li {
+		border-left: 3px solid transparent;
+		padding-left: 5px;
+		margin: 6px 0 0 0;
+	}
+
+	nav#dataset-menu ul li.current {
+		font-weight: bold;
+		border-left: 3px solid var(--color-blue2);
+	}
 }
 
 /* =========

--- a/preflibApp/static/css/style.css
+++ b/preflibApp/static/css/style.css
@@ -785,6 +785,44 @@ Index page
 }
 
 /* =========
+All datasets page
+========= */
+
+.data-patch-list .data-patch {
+	font-size: 80%;
+	background-color: var(--color-blue3);
+	box-shadow: 0px 0px 1px 0px var(--color-blue1);
+	padding: 2px 3px;
+	border-radius: 3px;
+}
+
+.data-patch-list .data-patch a {
+	color: black;
+	font-style: normal;
+}
+
+.button-row {
+	display: flex;
+	justify-content: center;
+	margin-top: 10px;
+	gap: 10px;
+}
+
+.button-row a {
+	font-style: normal;
+	color: white;
+	font-size: 90%;
+	background-color: var(--color-blue2);
+	box-shadow: 0px 0px 1px 0px var(--color-blue1);
+	padding: 4px;
+	border-radius: 5px;
+}
+
+.button-row a:hover {
+	background-color: var(--color-blue1);
+}
+
+/* =========
 Dataset page
 ========= */
 

--- a/preflibApp/templates/preflib/admin.html
+++ b/preflibApp/templates/preflib/admin.html
@@ -30,10 +30,11 @@
 		<h4><a href="{% url 'preflibapp:adminPaper' %}">Add a paper</a></h4>
 		<div class="adminMenuContent">
 				<a href="{% url 'preflibapp:adminPaper' %}"><img src="{% static 'adminLogo/scholar.png' %}" width="100%"></a>
-				<p>Use this form to add a paper that has been published and which uses PrefLib, it will appear on the <a href="{% url 'preflibapp:papers' %}">Papers page</a>.</p>
+				<p>Use this form to add a paper that has been published and which uses PrefLib, it will appear on the <a href="{% url 'preflibapp:main' %}">main page</a> of the website.</p>
 			</div>
 		</div>
 
+	{% comment %}
 	<div class="adminTab">
 		<h4><a href="{% url 'preflibapp:createUser' %}">Create an user</a></h4>
 		<div class="adminMenuContent">
@@ -41,6 +42,7 @@
 			<p> Use this form to create an user, you will be able to decide whether he or she should be a superuser or not.</p>
 		</div>
 	</div>
+	{% endcomment %}
 </div>
 
 <div class="adminMenu">

--- a/preflibApp/templates/preflib/datasetall.html
+++ b/preflibApp/templates/preflib/datasetall.html
@@ -19,14 +19,6 @@
 
 	<p>Here is a list of all the data sets in the {{ title }} category, showing 20 per page.</p>
 	
-	<ul>
-		{% for ds in datasets %}
-			<li>
-				<a href="#{{ds.category}}{{ds.seriesNumber}}">{{ ds.name }}</a>
-			</li>
-		{% endfor %}
-	</ul>
-
 	{% include 'includes/paginator.html' %}
 	
 	{% for dsinfo in datasetInfo %}

--- a/preflibApp/templates/preflib/datasetall.html
+++ b/preflibApp/templates/preflib/datasetall.html
@@ -17,17 +17,34 @@
 
 {% if datasets %}
 
-	<p>Here is a list of all the data sets in the {{ title }} category, showing 20 per page.</p>
+	<p>Here is a list of all data sets in the <em>{{ title }}</em> category.</p>
+
+	<p>Sort by: <a href="javascript:sortByName()" id="sort-name" style="font-weight: bold;">Dataset name (A-Z)</a> &middot; <a href="javascript:sortByNew()" id="sort-new">Newest first</a> &middot; <a href="javascript:sortByOld()" id="sort-old">Oldest first</a></p>
 	
-	{% include 'includes/paginator.html' %}
+	<section id="section-datasets">
+	<nav id="dataset-menu">
+		<ul>
+			{% for ds in datasets %}
+				<li data-number="{{ds.seriesNumber}}" data-name="{{ds.name}}"><a href="#{{ds.category}}-{{ds.seriesNumber}}">{{ ds.name }}</a></li>
+			{% endfor %}
+		</ul>
+	</nav>
 	
+	<ul id="dataset-list">
 	{% for dsinfo in datasetInfo %}
 	{% with dsinfo.ds as ds %}
-		<h2><a href="{% url 'preflibapp:dataset' ds.category ds.seriesNumber %}" id="{{ds.category}}{{ds.seriesNumber}}"> {{ ds.name }} </a></h2>
+	<li 
+	id="{{ds.category}}-{{ds.seriesNumber}}" 
+	data-number="{{ds.seriesNumber}}" data-name="{{ds.name}}">
+		<p class="dataset-title"><strong><a href="{% url 'preflibapp:dataset' ds.category ds.seriesNumber %}" id="{{ds.category}}{{ds.seriesNumber}}">{{ ds.name }}</a></strong></p>
 
+		<p class="dataset-number">{{ds.category}}-{{ds.seriesNumber}}</p>
+
+		<div class="dataset-description">
 		{% autoescape off %}
-		<p> {{ ds.description }} </p>
+			{{ ds.description }}
 		{% endautoescape %}
+		</div>
 
 		<p class="data-patch-list">
 			Consists of {{ dsinfo.nbPatches }} data patch{{ dsinfo.nbPatches|pluralize:"es" }}:
@@ -43,13 +60,98 @@
 			<a href="{% url 'preflibapp:dataset' ds.category ds.seriesNumber %}" class="details-button">Details</a>
 			<a href="{% static dsinfo.zipFile %}" class="downloadButton">Download [zip, {{dsinfo.zipFileSize|filesizeformat}}]</a>
 		</p>
+	</li>
 	{% endwith %}
 	{% endfor %}
+	</ul>
+	</section>
 
-	{% include 'includes/paginator.html' %}
-	
+	<script>
+		// sorting
+		var list = document.querySelector('#dataset-list');
+		var menu = document.querySelector('#dataset-menu ul');
+
+		function bolden(id) {
+			for (link of ["#sort-name", "#sort-new", "#sort-old"]) {
+				if (link == id) {
+					document.querySelector(link).style.fontWeight = "bold";
+				} else {
+					document.querySelector(link).style.fontWeight = "normal";
+				}
+			}
+		}
+
+		function sortByName() {
+			[...list.children]
+			.sort((a,b)=>a.dataset.name.localeCompare(b.dataset.name))
+			.forEach(node=>list.appendChild(node));
+			[...menu.children]
+			.sort((a,b)=>a.dataset.name.localeCompare(b.dataset.name))
+			.forEach(node=>menu.appendChild(node));
+			bolden("#sort-name");
+		}
+		function sortByNew() {
+			[...list.children]
+			.sort((a,b)=>b.dataset.number.localeCompare(a.dataset.number))
+			.forEach(node=>list.appendChild(node));
+			[...menu.children]
+			.sort((a,b)=>b.dataset.number.localeCompare(a.dataset.number))
+			.forEach(node=>menu.appendChild(node));
+			bolden("#sort-new");
+		}
+		function sortByOld() {
+			[...list.children]
+			.sort((a,b)=>a.dataset.number.localeCompare(b.dataset.number))
+			.forEach(node=>list.appendChild(node));
+			[...menu.children]
+			.sort((a,b)=>a.dataset.number.localeCompare(b.dataset.number))
+			.forEach(node=>menu.appendChild(node));
+			bolden("#sort-old");
+		}
+
+		// menu updates
+		function debounce(func, timeout = 300) {
+			let timer;
+			return (...args) => {
+				clearTimeout(timer);
+				timer = setTimeout(() => {
+				func.apply(this, args);
+				}, timeout);
+			};
+		}
+
+		function updateDatasetMenu() {
+			var current = "NOTHING";
+
+			// figure out where we are
+			document.querySelectorAll("#dataset-list li").forEach((section) => {
+				const sectionTop = section.offsetTop;
+				if (scrollY >= sectionTop - 122) {
+					current = section.dataset.number;
+					console.log(current);
+				}
+			});
+
+			// show current element in menu
+			document.querySelectorAll("#dataset-menu ul li").forEach((li) => {
+				li.classList.remove("current");
+				if (li.dataset.number == current) {
+					li.classList.add("current");
+					li.scrollIntoView({ block: "nearest" });
+				}
+			});
+		}
+
+		document.addEventListener("DOMContentLoaded", (event) => {
+			window.onscroll = () => {
+				debounce(updateDatasetMenu, 75)();
+			};
+		});
+
+	</script>
+
 {% else %}
-	<p> There are no such dataset right now, do you want to contribute? </p>
+	<p> There are no datasets in the <em>{{ title }}</em> category yet. Do you want to contribute? </p>
 {% endif %}
 
 </div>

--- a/preflibApp/templates/preflib/datasetall.html
+++ b/preflibApp/templates/preflib/datasetall.html
@@ -19,28 +19,45 @@
 
 	<p>Here is a list of all the data sets in the {{ title }} category, showing 20 per page.</p>
 	
+	<ul>
+		{% for ds in datasets %}
+			<li>
+				<a href="#{{ds.category}}{{ds.seriesNumber}}">{{ ds.name }}</a>
+			</li>
+		{% endfor %}
+	</ul>
+
 	{% include 'includes/paginator.html' %}
 	
-	{% for ds in datasets %}
-		<h2> <a href="{% url 'preflibapp:dataset' ds.category ds.seriesNumber %}"> {{ ds.name }} </a></h2>
+	{% for dsinfo in datasetInfo %}
+	{% with dsinfo.ds as ds %}
+		<h2><a href="{% url 'preflibapp:dataset' ds.category ds.seriesNumber %}" id="{{ds.category}}{{ds.seriesNumber}}"> {{ ds.name }} </a></h2>
 
 		{% autoescape off %}
 		<p> {{ ds.description }} </p>
 		{% endautoescape %}
 
-		<p> Want to have more details, see <a href="{% url 'preflibapp:dataset' ds.category ds.seriesNumber %}"> this page</a>.</p>
+		<p class="data-patch-list">
+			Consists of {{ dsinfo.nbPatches }} data patch{{ dsinfo.nbPatches|pluralize:"es" }}:
+			{% for patch in dsinfo.patches %}
+				<span class="data-patch"><a href="{% url 'preflibapp:datapatch' ds.category ds.seriesNumber patch.seriesNumber %}">{{ patch.description }}</a></span>
+			{% endfor %}
+			{% if dsinfo.nbPatchesNotShown > 0 %}
+				and {{ dsinfo.nbPatchesNotShown }} more.
+			{% endif %}
+		</p>
 
-		{% with 'data/'|add:ds.category|add:'/'|add:ds.abbreviation|add:'/'|add:ds.abbreviation|add:'.zip' as zip_static %}
-			<p id="center_p">
-				<a href="{% static zip_static %}" id="downloadButton">Click here to download the dataset</a>
-			</p>
-		{% endwith %}
+		<p class="button-row">
+			<a href="{% url 'preflibapp:dataset' ds.category ds.seriesNumber %}" class="details-button">Details</a>
+			<a href="{% static dsinfo.zipFile %}" class="downloadButton">Download [zip, {{dsinfo.zipFileSize|filesizeformat}}]</a>
+		</p>
+	{% endwith %}
 	{% endfor %}
 
 	{% include 'includes/paginator.html' %}
 	
 {% else %}
-	<p> There are no such dataset right now, do you want to contribute ? </p>
+	<p> There are no such dataset right now, do you want to contribute? </p>
 {% endif %}
 
 </div>

--- a/preflibApp/templates/preflib/datasetall.html
+++ b/preflibApp/templates/preflib/datasetall.html
@@ -35,7 +35,7 @@
 				<span class="data-patch"><a href="{% url 'preflibapp:datapatch' ds.category ds.seriesNumber patch.seriesNumber %}">{{ patch.description }}</a></span>
 			{% endfor %}
 			{% if dsinfo.nbPatchesNotShown > 0 %}
-				and {{ dsinfo.nbPatchesNotShown }} more.
+				and <a href="{% url 'preflibapp:dataset' ds.category ds.seriesNumber %}">{{ dsinfo.nbPatchesNotShown }} more</a>.
 			{% endif %}
 		</p>
 

--- a/preflibApp/views.py
+++ b/preflibApp/views.py
@@ -122,6 +122,24 @@ def dataMetadata(request):
 def alldatasets(request, datacategory):
 	(paginator, datasets, page, pagesBefore, pagesAfter) = getPaginator(request, DataSet.objects.filter(category = datacategory).order_by('name'))
 	title = findChoiceValue(DATACATEGORY, datacategory)
+	datasetInfo = []
+	for dataset in datasets:
+		patches = DataPatch.objects.filter(dataSet = dataset)
+		zipFilePath = os.path.join('data', datacategory, str(dataset.abbreviation), str(dataset.abbreviation) + '.zip')
+		staticDir = finders.find(zipFilePath)
+		if staticDir != None:
+			zipFileSize = os.path.getsize(staticDir)
+		else:
+			zipFileSize = 0
+		show_how_many_patches = 7
+		datasetInfo.append({
+			"ds": dataset, 
+			"patches": patches[:show_how_many_patches], 
+			"nbPatches": patches.count(),
+			"nbPatchesNotShown": max(0, patches.count() - show_how_many_patches),
+			"zipFile": zipFilePath,
+			"zipFileSize": zipFileSize
+		})
 	return my_render(request, os.path.join('preflib', 'datasetall.html'), locals())
 
 def dataset(request, datacategory, dataSetNum):

--- a/preflibApp/views.py
+++ b/preflibApp/views.py
@@ -120,7 +120,8 @@ def dataMetadata(request):
 	return my_render(request, os.path.join('preflib', 'datametadata.html'), locals())
 
 def alldatasets(request, datacategory):
-	(paginator, datasets, page, pagesBefore, pagesAfter) = getPaginator(request, DataSet.objects.filter(category = datacategory).order_by('name'))
+	# (paginator, datasets, page, pagesBefore, pagesAfter) = getPaginator(request, DataSet.objects.filter(category = datacategory).order_by('name'))
+	datasets = DataSet.objects.filter(category = datacategory).order_by('name')
 	title = findChoiceValue(DATACATEGORY, datacategory)
 	datasetInfo = []
 	for dataset in datasets:


### PR DESCRIPTION
I am proposing a redesign of the dataset list pages (see [demo](https://dominik-peters.de/preflib/datasetall.html)), with the following changes:
- Remove pagination: there are not that many datasets, so it is not needed much, and pagination makes it harder to use (for example, you can't use Ctrl+F to search).
- Give a list of the data patches belonging to a dataset. (Showing the first seven.) This makes it easier to see which datasets are "bigger" than others, and makes it easier to understand their structure. <img width="1055" alt="image" src="https://user-images.githubusercontent.com/3543224/182018262-60f21c4b-5884-4d91-8e1f-98153bb8a570.png">
- Add a "Details" button next to the Download Zip button
- Add zip file size to the download button
- Show dataset numbers like ED-00007
- Sort datasets (via javascript), either by name or by dataset number.
- Show a sidebar list for faster navigation.

<img width="964" alt="image" src="https://user-images.githubusercontent.com/3543224/182018111-41791900-1e78-4c4f-b863-4a340671b9b6.png">
