### PR TITLE
Fix scrolling issue

### DIFF
--- a/preflibApp/static/css/style.css
+++ b/preflibApp/static/css/style.css
@@ -826,18 +826,18 @@ ul#dataset-list {
 	}
 }
 
-ul#dataset-list li {
+ul#dataset-list > li {
 	padding-top: 0;
 	margin-top: 0;
 	font-size: 100%;
 }
 
-ul#dataset-list li:not(:first-child) {
+ul#dataset-list > li:not(:first-child) {
 	border-top: 1px solid #ddd;
 	margin-top: 20px;
 }
 
-ul#dataset-list li:first-child .dataset-title {
+ul#dataset-list > li:first-child .dataset-title {
 	margin-top: 0px;
 }
 
@@ -918,9 +918,10 @@ nav#dataset-menu {
 		padding: 0;
 		margin: 0;
 		margin-left: -5px;
-		overflow-y: scroll;
+		overflow-y: auto;
 		max-height: 100vh;
 		font-size: 90%;
+		scroll-padding: 100px;
 	}
 
 	nav#dataset-menu ul li {

--- a/preflibApp/templates/preflib/datasetall.html
+++ b/preflibApp/templates/preflib/datasetall.html
@@ -124,11 +124,10 @@
 			var current = "NOTHING";
 
 			// figure out where we are
-			document.querySelectorAll("#dataset-list li").forEach((section) => {
+			document.querySelectorAll("#dataset-list > li").forEach((section) => {
 				const sectionTop = section.offsetTop;
 				if (scrollY >= sectionTop - 122) {
 					current = section.dataset.number;
-					console.log(current);
 				}
 			});
 
@@ -137,7 +136,7 @@
 				li.classList.remove("current");
 				if (li.dataset.number == current) {
 					li.classList.add("current");
-/*					li.scrollIntoView({ block: "nearest" });*/
+					li.scrollIntoView({ block: "nearest" });
 				}
 			});
 		}


### PR DESCRIPTION
I think it works better now. (The idea is that the left sidebar should scroll so that the current dataset is visible.) The `scroll-padding` fixes it.

I've also changed a few `ul#dataset-list li` to `ul#dataset-list > li` so that the list in the description of the sushi data set is not captured.